### PR TITLE
Make contributions easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![](https://badgen.net/badge/support%20me/donate/ff00ff)](https://www.patreon.com/HcySunYang)
 [![](https://img.shields.io/badge/all_contributors-3-orange.svg)](#contributing)
 [![](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![](https://img.shields.io/badge/Gitpod-contribute-blue.svg?longCache=true)](https://gitpod.io#https://github.com/vuese/vuese)
 
 ## Online experience
 
@@ -242,7 +243,7 @@ interface ParserOptions {
 }
 ```
 
-The [default parsing option](https://github.com/HcySunYang/vuese/blob/master/src/parser/index.ts#L76) is: 
+The [default parsing option](https://github.com/HcySunYang/vuese/blob/master/src/parser/index.ts#L76) is:
 
 ```js
 const defaultOptions: ParserOptions = {
@@ -563,7 +564,7 @@ export default class Child extends Vue {
   /**
    * @vuese
    * This is a function exposed as an interface
-   * 
+   *
    * @arg The first parameter is a Boolean value that represents...
    */
   someMethod(a) {
@@ -619,7 +620,7 @@ Add leading comments to the `@Emit` decorator as a description of the event, oth
 ```js
 @Component
 export default class Child extends Vue {
-  
+
   // Fire when the form is cleared
   // @arg The argument is a boolean value representing xxx
   @Emit()


### PR DESCRIPTION
Contributing to GitHub repos is simplified with Gitpod.io as you don't have to manually checkout locally and setup a dev environment. Also the workflow of forking and creating a PR is integrated. Contributors can simply click the badge and start coding. It is free, has excellent TypeScript integration and supports node debugging (based on vs code `launch.json`).

I added the vuese specific configuration, that will start `yarn && yarn build` automatically [here](https://github.com/gitpod-io/definitely-gp/tree/master/vuese). If you are not happy with it you can override the behavior by adding your own `.gitpod.yml` in the root of the repository (or ask me to change it :-)).

Try: https://gitpod.io#https://github.com/vuese/vuese

Here is what the dev environment looks like:
<img width="1345" alt="screenshot 2019-01-09 at 09 51 05" src="https://user-images.githubusercontent.com/372735/50887807-70fbaa00-13f4-11e9-80f6-afddfeea2802.png">
